### PR TITLE
feat: Implement multi-db historical data collection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,25 @@ REMOTE_SERVER_4_JUMP_SERVER="2"
 # Refresh interval for the main server list page, in milliseconds.
 # Default is 15000ms (15 seconds) if not set.
 # SERVER_LIST_REFRESH_INTERVAL_MS=15000
+
+# -----------------------------------------------------------------------------
+# DATABASE CONFIGURATION
+# -----------------------------------------------------------------------------
+# Specify the type of database to use. Options: "sqlite" or "postgresql".
+# Defaults to "sqlite" if not set.
+DATABASE_TYPE=sqlite
+
+# --- PostgreSQL Specific Configuration ---
+# Required if DATABASE_TYPE is "postgresql".
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_USER=your_postgres_user
+POSTGRES_PASSWORD=your_postgres_password
+POSTGRES_DBNAME=sys_stats
+
+# -----------------------------------------------------------------------------
+# DATA COLLECTION SETTINGS
+# -----------------------------------------------------------------------------
+# Interval (in seconds) for collecting historical data for all servers.
+# Defaults to 60 seconds if not set or invalid.
+DATA_GATHERING_INTERVAL_SECONDS=60

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 psutil
 python-dotenv
 paramiko
+psycopg2-binary>=2.9


### PR DESCRIPTION
This commit introduces several enhancements to the server monitoring application:

1.  **Database Flexibility:**
    *   The application now supports both SQLite and PostgreSQL for storing historical system statistics.
    *   Database type and connection parameters are configurable via environment variables (`DATABASE_TYPE`, `POSTGRES_HOST`, etc.).
    *   Database initialization (`init_db`) and data storage (`store_stats`) logic have been updated to handle both database systems.
    *   The `stats` table schema now includes a `server_name` column to differentiate records from multiple servers.

2.  **Comprehensive Historical Data Collection:**
    *   The `historical_data_collector` background thread now gathers statistics not only from the local machine but also from all configured remote servers.
    *   It iterates through server configurations, fetches data using existing SSH mechanisms for remote servers, and stores it tagged with the server's name.
    *   Error handling has been improved to ensure issues with one server do not halt the entire collection process.

3.  **Configurable Collection Interval:**
    *   The interval for the `historical_data_collector` loop is now configurable via the `DATA_GATHERING_INTERVAL_SECONDS` environment variable.

4.  **Enhanced API Endpoint:**
    *   The `/api/historical_stats` endpoint can now filter data by `server_name` using a query parameter. It defaults to 'local' if no server is specified.
    *   The JSON response for this endpoint now includes the `server_name` for which data is being returned.

5.  **Dependency and Configuration Updates:**
    *   `psycopg2-binary` has been added to `requirements.txt` for PostgreSQL support.
    *   `.env.example` has been updated with the new environment variables and explanatory comments.

These changes allow for more robust and flexible historical data logging, enabling you to monitor multiple servers and choose your preferred database backend.